### PR TITLE
Bump up JaCoCo version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.1</version>
+				<version>0.8.5</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
Tentatively fixing build on JDK 14, since JaCoCo 0.8.5 has experimental support for that version.